### PR TITLE
use ATS endpoint type

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ aws s3 mb s3://my-cf-helpers
 
 # Get the endpoint address for your AWS account, you'll need to provide it as
 # a parameter for your stack:
-AWS_IOT_ENDPOINT=$(aws iot describe-endpoint --output text)
+AWS_IOT_ENDPOINT=$(aws iot describe-endpoint --endpoint-type iot:Data-ATS --output text)
 
 # Now, "package" the template. Packaging includes copying source code of the
 # helper functions from local machine to the s3 bucket we created above,


### PR DESCRIPTION
Browsers no longer support the Symantec certificates of the non ATS endpoint
https://aws.amazon.com/blogs/iot/aws-iot-core-ats-endpoints/
Without this change, when the demo page is loaded a 
`NET::ERR_CERT_AUTHORITY_INVALID` is reported by the browser.